### PR TITLE
タグの自動補完を実装

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -28,7 +28,13 @@ class ArticleController extends Controller
     // 記事投稿画面
     public function create()
     {
-        return view('articles.create');
+        // タグの自動補完のためにすべてのタグをViewに渡す
+        $allTagNames = Tag::all()->map(function ($tag) {
+            return ['text' => $tag->name];
+        });
+        return view('articles.create', [
+            'allTagNames' => $allTagNames,
+        ]);
     }
 
     // 記事の保存
@@ -67,9 +73,14 @@ class ArticleController extends Controller
         $tagNames = $article->tags->map(function ($tag) {
             return ['text' => $tag->name];
         });
+        // タグの自動補完のためにすべてのタグをViewに渡す
+        $allTagNames = Tag::all()->map(function ($tag) {
+            return ['text' => $tag->name];
+        });
         return view('articles.edit', [
             'article' => $article,
             'tagNames' => $tagNames,
+            'allTagNames' => $allTagNames,
         ]);
     }
 

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -27,22 +27,15 @@ export default {
       type: Array,
       default: [],
     },
+    autocompleteItems: {
+      type: Array,
+      default: [],
+    },
   },
   data() {
     return {
       tag: '',
       tags: this.initialTags,
-      autocompleteItems: [{
-        text: 'Spain',
-      }, {
-        text: 'France',
-      }, {
-        text: 'USA',
-      }, {
-        text: 'Germany',
-      }, {
-        text: 'China',
-      }],
     };
   },
   computed: {

--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -8,6 +8,7 @@
 <div class="form-group">
   <article-tags-input
     :initial-tags='@json($tagNames ?? [])'
+    :autocomplete-items='@json($allTagNames ?? [])'
   >
   </article-tags-input>
 </div>


### PR DESCRIPTION
タグの自動補完を実装
* すべてのタグを取得してViewに渡す
* form.blade.phpからArticleTagsInputコンポーネントにタグデータを渡す
* ArticleTagsInputのautocompleteItemsに渡す