### PR TITLE
ユーザーページの記事一覧実装

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -7,13 +7,29 @@ use Illuminate\Http\Request;
 
 class UserController extends Controller
 {
-    // ユーザーページ
+    // ユーザーページ（ユーザーが投稿した記事一覧画面）
     public function show(string $name)
     {
         $user = User::where('name', $name)->first();
 
+        $articles = $user->articles->sortByDesc('created_at');
+
         return view('users.show', [
             'user' => $user,
+            'articles' => $articles,
+        ]);
+    }
+
+    // いいねした記事一覧画面
+    public function likes(string $name)
+    {
+        $user = User::where('name', $name)->first();
+
+        $articles = $user->likes->sortByDesc('created_at');
+
+        return view('users.likes', [
+            'user' => $user,
+            'articles' => $articles,
         ]);
     }
 

--- a/app/User.php
+++ b/app/User.php
@@ -6,6 +6,7 @@ use App\Mail\BareMail;
 use App\Notifications\PasswordResetNotification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -45,6 +46,12 @@ class User extends Authenticatable
         $this->notify(new PasswordResetNotification($token, new BareMail()));
     }
 
+    // ユーザーが投稿した記事モデルにアクセスできるようにリレーションを定義
+    public function articles(): HasMany
+    {
+        return $this->hasMany('App\Article');
+    }
+
     // あるユーザーをフォローしているのユーザーの一覧を取得
     public function followers(): BelongsToMany
     {
@@ -60,6 +67,12 @@ class User extends Authenticatable
     public function followings(): BelongsToMany
     {
         return $this->belongsToMany('App\User', 'follows', 'follower_id', 'followee_id')->withTimestamps();
+    }
+
+    // ユーザーがいいねした記事のリレーション定義
+    public function likes(): BelongsToMany
+    {
+        return $this->belongsToMany('App\Article', 'likes')->withTimestamps();
     }
 
     // ログインユーザーが現在表示中のユーザーをフォローしているかどうかを判定する

--- a/resources/views/users/likes.blade.php
+++ b/resources/views/users/likes.blade.php
@@ -1,0 +1,17 @@
+@extends('app')
+
+@section('title', $user->name . 'のいいねした記事')
+
+@section('content')
+  @include('nav')
+  <div class="container">
+    @include('users.user')
+    @include('users.tabs', [
+      'hasArticles' => false,
+      'hasLikes' => true,
+    ])
+    @foreach($articles as $article)
+      @include('articles.card')
+    @endforeach
+  </div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -5,39 +5,13 @@
 @section('content')
 @include('nav')
 <div class="container">
-  <div class="card mt-3">
-    <div class="card-body">
-      <div class="d-flex flex-row">
-        <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
-          <i class="fas fa-user-circle fa-3x"></i>
-        </a>
-        {{-- 自分自身をフォローできないようにする --}}
-        @if (Auth::id() !== $user->id)
-            <follow-button
-              class="ml-auto"
-              :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
-              :authorized='@json(Auth::check())'
-              endpoint="{{ route('users.follow', ['name' => $user->name]) }}"
-            >
-            </follow-button>
-        @endif
-      </div>
-      <h2 class="h5 card-title m-0">
-        <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
-          {{ $user->name }}
-        </a>
-      </h2>
-    </div>
-    <div class="card-body">
-      <div class="card-text">
-        <a href="" class="text-muted">
-          {{ $user->count_followings }} フォロー
-        </a>
-        <a href="" class="text-muted">
-          {{ $user->count_followers }} フォロワー
-        </a>
-      </div>
-    </div>
-  </div>
+  @include('users.user')
+  @include('users.tabs', [
+    'hasArticles' => true,
+    'hasLikes' => false,
+  ])
+  @foreach ($articles as $article)
+      @include('articles.card')
+  @endforeach
 </div>
 @endsection

--- a/resources/views/users/tabs.blade.php
+++ b/resources/views/users/tabs.blade.php
@@ -1,0 +1,12 @@
+<ul class="nav nav-tabs nav-justified mt-3">
+  <li class="nav-item">
+    <a class="nav-link text-muted {{ $hasArticles ? 'active' : '' }}" href="{{ route('users.show', ['name' => $user->name]) }}">
+      記事
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link text-muted {{ $hasLikes ? 'active' : '' }}" href="{{ route('users.likes', ['name' => $user->name]) }}">
+      いいね
+    </a>
+  </li>
+</ul>

--- a/resources/views/users/user.blade.php
+++ b/resources/views/users/user.blade.php
@@ -1,0 +1,29 @@
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="d-flex flex-row">
+      <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
+        <i class="fas fa-user-circle fa-3x"></i>
+      </a>
+      {{-- 自分自身をフォローできないようにする --}}
+      @if(Auth::id() !== $user->id)
+        <follow-button class="ml-auto" :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))' :authorized='@json(Auth::check())' endpoint="{{ route('users.follow', ['name' => $user->name]) }}">
+        </follow-button>
+      @endif
+    </div>
+    <h2 class="h5 card-title m-0">
+      <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
+        {{ $user->name }}
+      </a>
+    </h2>
+  </div>
+  <div class="card-body">
+    <div class="card-text">
+      <a href="" class="text-muted">
+        {{ $user->count_followings }} フォロー
+      </a>
+      <a href="" class="text-muted">
+        {{ $user->count_followers }} フォロワー
+      </a>
+    </div>
+  </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ Route::get('/tags/{name}', 'TagController@show')->name('tags.show');
 // ユーザーページ
 Route::prefix('users')->name('users.')->group(function () {
     Route::get('/{name}', 'UserController@show')->name('show');
+    Route::get('/{name}/likes', 'UserController@likes')->name('likes');
     Route::middleware('auth')->group(function () {
         Route::put('/{name}/follow', 'UserController@follow')->name('follow');
         Route::delete('/{name}/follow', 'UserController@unfollow')->name('unfollow');


### PR DESCRIPTION
# 概要
* ユーザーページに下記を追加
    * ユーザーが投稿した記事一覧
    * ユーザーがいいねした記事一覧
* それぞれの記事一覧が取得できるようにリレーション定義を追加
* いいねした記事一覧のルーティングとアクションメソッドを追加
* bladeテンプレートを共通部分を切り出し
    * ユーザープロフィール部分(users.user)
    * タブ(users.tabs)

# 確認
https://gyazo.com/0f340c6319bce86ad2fdb9618978605a