### PR TITLE
Googleアカウントを使ったユーザー登録 未登録ユーザーの場合の登録画面を実装

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -6,8 +6,10 @@ use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Laravel\Socialite\Facades\Socialite;
 
 class RegisterController extends Controller
 {
@@ -68,6 +70,20 @@ class RegisterController extends Controller
             'name' => $data['name'],
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
+        ]);
+    }
+
+    // OAuth認証で未登録ユーザーの場合の登録画面
+    public function showProviderUserRegistrationForm(Request $request, string $provider)
+    {
+        $token = $request->token;
+
+        $providerUser = Socialite::driver($provider)->userFromToken($token);
+
+        return view('auth.social_register', [
+            'provider' => $provider,
+            'email' => $providerUser->getEmail(),
+            'token' => $token,
         ]);
     }
 }

--- a/resources/views/auth/social_register.blade.php
+++ b/resources/views/auth/social_register.blade.php
@@ -1,0 +1,36 @@
+@extends('app')
+
+@section('title', 'ユーザー登録')
+
+@section('content')
+<div class="container">
+  <div class="row">
+    <div class="mx-auto col col-12 col-sm-11 col-md-9 col-lg-7 col-xl-6">
+      <h1 class="text-center"><a class="text-dark" href="/">memo</a></h1>
+      <div class="card mt-3">
+        <div class="card-body text-center">
+          <h2 class="h3 card-title text-center mt-2">ユーザー登録</h2>
+
+          @include('error_card_list')
+          <div class="card-text">
+            <form method="POST" action="">
+              @csrf
+              <input type="hidden" name="token" value="{{ $token }}">
+              <div class="md-form">
+                <label for="name">ユーザー名</label>
+                <input class="form-control" type="text" id="name" name="name" required>
+                <small>英数字3〜16文字(登録後の変更はできません)</small>
+              </div>
+              <div class="md-form">
+                <label for="email">メールアドレス</label>
+                <input class="form-control" type="text" id="email" name="email" value="{{ $email }}" disabled>
+              </div>
+              <button class="btn btn-block blue-gradient mt-2 mb-2" type="submit">ユーザー登録</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,12 @@ Route::prefix('login')->name('login.')->group(function () {
     Route::get('/{provider}', 'Auth\LoginController@redirectToProvider')->name('{provider}');
     Route::get('{provider}/callback', 'Auth\LoginController@handleProviderCallback')->name('{provider}.callback');
 });
+
+// OAuth認証の場合で、未登録ユーザーの場合にユーザ名設定を行ってもらう
+Route::prefix('register')->name('register.')->group(function() {
+    Route::get('/{provider}', 'Auth\RegisterController@showProviderUserRegistrationForm')->name('{provider}');
+});
+
 Route::get('/', 'ArticleController@index')->name('articles.index');
 Route::resource('/articles', 'ArticleController')->except(['index', 'show'])->middleware('auth');
 // 記事詳細画面はログインユーザーじゃなくても見れるようにしたいので、部分的にauthミドルウェアがついていないルートを定義する


### PR DESCRIPTION
* 現在未登録のユーザーがGoogleアカウントでユーザー登録を行った場合、下記のように動作させる
    * メールアドレスはGoogleアカウントのものを流用
    * パスワードは登録不要
    * ユーザー名は設定してもらう（ユニーク制約に引っかかる可能性があるため）