### PR TITLE
記事一覧のN+1問題を回避

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -20,7 +20,7 @@ class ArticleController extends Controller
         // allメソッドはコレクションを返す
         // sortByDescはコレクションのメソッド
         // 参考: https://readouble.com/laravel/6.x/ja/collections.html
-        $articles = Article::all()->sortByDesc('created_at');
+        $articles = Article::all()->sortByDesc('created_at')->load(['user', 'likes', 'tags']);
 
         return view('articles.index', ['articles' => $articles]);
     }


### PR DESCRIPTION
* EagerLoadを使用することでN+1問題を回避
* クエリ発行数は11→4に減少したことを確認